### PR TITLE
Add configuration file support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ chan-signal = "0.2"
 chan = "0.1"
 clap = "2"
 lazy_static = "0.2"
+rust-ini = "0.10"
 
 dbus = { version = "0.5", optional = true }
 

--- a/src/location/mod.rs
+++ b/src/location/mod.rs
@@ -57,17 +57,3 @@ impl FromStr for Location {
                     |trailing| m(format!("location: trailing {} (of {})", trailing, s)))
     }
 }
-
-/// Determine the current location from the given argument.
-///
-/// The location can either be specified as <LAT:LON> or by naming a
-/// particular location provider. If a provider exists whose name
-/// matches the input, then that provider is tried. Otherwise, the
-/// argument is attempted parsed as "LAT:LON".
-///
-/// If the location argument is omitted, a default is chosen.
-pub fn determine(location_arg: &str) -> Result<Location> {
-    // Look for provider and use if matched, otherwise parse
-    // as LAT:LON.
-    location_arg.parse::<Location>()
-}

--- a/src/location/mod.rs
+++ b/src/location/mod.rs
@@ -66,13 +66,8 @@ impl FromStr for Location {
 /// argument is attempted parsed as "LAT:LON".
 ///
 /// If the location argument is omitted, a default is chosen.
-pub fn determine(location_arg: Option<&str>) -> Result<Location> {
-    match location_arg {
-        Some(loc) => {
-            // Look for provider and use if matched, otherwise parse
-            // as LAT:LON.
-            loc.parse::<Location>()
-        }
-        None => Ok(Location::new(55.7, 12.6))
-    }
+pub fn determine(location_arg: &str) -> Result<Location> {
+    // Look for provider and use if matched, otherwise parse
+    // as LAT:LON.
+    location_arg.parse::<Location>()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,7 +269,7 @@ impl Args {
         };
 
         if let Some(location) = matches.value_of("location") {
-            self.location = location::determine(location)?;
+            self.location = location.parse()?;
         }
 
         self.method = matches.value_of("method").map(ToOwned::to_owned)

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,7 +233,9 @@ impl Args {
         }
 
         if let Some(method) = section.get("adjustment-method") {
-            self.method = Some(method.to_owned());
+            self.method = determine_gamma_method(method.to_owned())
+                .or_else(|e| malformed_config(format!("{}", e)))
+                .map(Some)?;
         }
 
         Ok(self)
@@ -276,9 +278,10 @@ impl Args {
             self.location = location.parse()?;
         }
 
-        self.method = matches.value_of("method").map(ToOwned::to_owned)
-            .map_or(Ok(None), |s| determine_gamma_method(s).map(Some))?
-            .or(self.method);
+        if let Some(method) = matches.value_of("method") {
+            self.method = determine_gamma_method(method.to_owned()).map(Some)?;
+        }
+
         self.verbose = matches.is_present("verbose");
         self.transition = !matches.is_present("no-transition");
 


### PR DESCRIPTION
Support the same configuration file format as the original redshift and
look for it in the same place (`~/.config/redshift.conf`).